### PR TITLE
Add small option to the installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,4 +35,7 @@ Demo of current progress:
     ```bash
     php -S localhost:8080 -t public
     ```
-7. Run tests with `./vendor/bin/phpunit`.
+7. Run `php artisan key:generate`
+
+8. Run tests with `./vendor/bin/phpunit`.
+


### PR DESCRIPTION
I was missing the `php artisan key:generate` and because of that, I got an encrypter error.
So I think it would be nice to let people remember they have to run that :)